### PR TITLE
Specify MySQL connector version in backend pom

### DIFF
--- a/bend/pom.xml
+++ b/bend/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
+      <version>8.0.33</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary
- set explicit `mysql-connector-j` version to resolve missing dependency error during build

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a564290833394a303f4ed6e6db4