### PR TITLE
chore: run backend on port 19988

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 cd bend
 mvn -q spring-boot:run
 ```
-应用运行在 `http://localhost:8088/api/v1`，Swagger UI `/swagger-ui.html`。
+应用运行在 `http://localhost:19988/api/v1`，Swagger UI `/swagger-ui.html`。
 
 ## 运行前端
 ```bash
@@ -14,6 +14,7 @@ npm i
 npm run serve
 ```
 默认访问 `http://localhost:8080`。
+前端会请求运行在 `http://localhost:19988` 的后端服务。
 
 ## 初始化数据库
 将 `bend/src/main/resources/db/schema.sql` 在 MySQL 中执行以创建并导入样例数据。

--- a/bend/src/main/resources/application.yml
+++ b/bend/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8088
+  port: 19988
   servlet:
     context-path: /api/v1
 spring:

--- a/fend/src/api/http.js
+++ b/fend/src/api/http.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { Message } from 'element-ui'
 
 const service = axios.create({
-  baseURL: '/api/v1'
+  baseURL: 'http://localhost:19988/api/v1'
 })
 
 service.interceptors.response.use(resp => {


### PR DESCRIPTION
## Summary
- serve backend on port 19988
- point frontend requests to backend port 19988
- document new backend port

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4588a692c83338b9a5e3217124bfb