### PR TITLE
Configure global CORS mappings

### DIFF
--- a/bend/src/main/java/com/kms/config/WebConfig.java
+++ b/bend/src/main/java/com/kms/config/WebConfig.java
@@ -2,10 +2,14 @@ package com.kms.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class WebConfig implements WebMvcConfigurer {
 
     @Value("${upload.dir}")
@@ -15,5 +19,15 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/files/**")
                 .addResourceLocations("file:" + uploadDir + "/");
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## Summary
- enable cross-origin requests for all endpoints with allowed methods, headers, and credentials
- ensure CORS config takes highest precedence

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a5355607dc833398f6e2592c30bcac