### PR TITLE
Add category management backend and update frontend

### DIFF
--- a/bend/src/main/java/com/kms/controller/CategoryController.java
+++ b/bend/src/main/java/com/kms/controller/CategoryController.java
@@ -1,0 +1,51 @@
+package com.kms.controller;
+
+import com.kms.common.R;
+import com.kms.dto.CategoryStatusReq;
+import com.kms.dto.CategoryTreeNode;
+import com.kms.dto.IdReq;
+import com.kms.entity.CategoryDO;
+import com.kms.service.CategoryService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/category")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/tree")
+    public R<List<CategoryTreeNode>> tree() {
+        return R.ok(categoryService.tree());
+    }
+
+    @PostMapping("/create")
+    public R<?> create(@RequestBody CategoryDO category) {
+        categoryService.create(category);
+        return R.ok();
+    }
+
+    @PostMapping("/update")
+    public R<?> update(@RequestBody CategoryDO category) {
+        categoryService.update(category);
+        return R.ok();
+    }
+
+    @PostMapping("/delete")
+    public R<?> delete(@RequestBody IdReq req) {
+        categoryService.delete(req.getId());
+        return R.ok();
+    }
+
+    @PostMapping("/status")
+    public R<?> updateStatus(@RequestBody CategoryStatusReq req) {
+        categoryService.updateStatus(req.getId(), req.getStatus());
+        return R.ok();
+    }
+}

--- a/bend/src/main/java/com/kms/dto/CategoryStatusReq.java
+++ b/bend/src/main/java/com/kms/dto/CategoryStatusReq.java
@@ -1,0 +1,12 @@
+package com.kms.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+
+@Data
+public class CategoryStatusReq {
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long id;
+    private Integer status;
+}

--- a/bend/src/main/java/com/kms/dto/CategoryTreeNode.java
+++ b/bend/src/main/java/com/kms/dto/CategoryTreeNode.java
@@ -1,0 +1,21 @@
+package com.kms.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class CategoryTreeNode {
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long id;
+    private String name;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long parentId;
+    private Integer recommend;
+    private Integer status;
+    private String remark;
+    private List<CategoryTreeNode> children = new ArrayList<>();
+}

--- a/bend/src/main/java/com/kms/dto/IdReq.java
+++ b/bend/src/main/java/com/kms/dto/IdReq.java
@@ -1,0 +1,11 @@
+package com.kms.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+
+@Data
+public class IdReq {
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long id;
+}

--- a/bend/src/main/java/com/kms/entity/CategoryDO.java
+++ b/bend/src/main/java/com/kms/entity/CategoryDO.java
@@ -1,0 +1,26 @@
+package com.kms.entity;
+
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@TableName("category")
+public class CategoryDO {
+    @TableId
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long id;
+    private String name;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long parentId;
+    private Integer recommend;
+    private Integer status;
+    private String remark;
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/bend/src/main/java/com/kms/mapper/CategoryMapper.java
+++ b/bend/src/main/java/com/kms/mapper/CategoryMapper.java
@@ -1,0 +1,9 @@
+package com.kms.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.kms.entity.CategoryDO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface CategoryMapper extends BaseMapper<CategoryDO> {
+}

--- a/bend/src/main/java/com/kms/service/CategoryService.java
+++ b/bend/src/main/java/com/kms/service/CategoryService.java
@@ -1,0 +1,14 @@
+package com.kms.service;
+
+import com.kms.dto.CategoryTreeNode;
+import com.kms.entity.CategoryDO;
+
+import java.util.List;
+
+public interface CategoryService {
+    List<CategoryTreeNode> tree();
+    void create(CategoryDO category);
+    void update(CategoryDO category);
+    void delete(Long id);
+    void updateStatus(Long id, Integer status);
+}

--- a/bend/src/main/java/com/kms/service/impl/CategoryServiceImpl.java
+++ b/bend/src/main/java/com/kms/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,65 @@
+package com.kms.service.impl;
+
+import com.kms.dto.CategoryTreeNode;
+import com.kms.entity.CategoryDO;
+import com.kms.mapper.CategoryMapper;
+import com.kms.service.CategoryService;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryMapper categoryMapper;
+
+    public CategoryServiceImpl(CategoryMapper categoryMapper) {
+        this.categoryMapper = categoryMapper;
+    }
+
+    @Override
+    public List<CategoryTreeNode> tree() {
+        List<CategoryDO> list = categoryMapper.selectList(null);
+        Map<Long, CategoryTreeNode> map = new HashMap<>();
+        List<CategoryTreeNode> roots = new ArrayList<>();
+        for (CategoryDO c : list) {
+            CategoryTreeNode node = new CategoryTreeNode();
+            BeanUtils.copyProperties(c, node);
+            map.put(c.getId(), node);
+        }
+        for (CategoryTreeNode node : map.values()) {
+            Long pid = node.getParentId();
+            if (pid != null && map.containsKey(pid)) {
+                map.get(pid).getChildren().add(node);
+            } else {
+                roots.add(node);
+            }
+        }
+        return roots;
+    }
+
+    @Override
+    public void create(CategoryDO category) {
+        categoryMapper.insert(category);
+    }
+
+    @Override
+    public void update(CategoryDO category) {
+        categoryMapper.updateById(category);
+    }
+
+    @Override
+    public void delete(Long id) {
+        categoryMapper.deleteById(id);
+    }
+
+    @Override
+    public void updateStatus(Long id, Integer status) {
+        CategoryDO entity = categoryMapper.selectById(id);
+        if (entity != null) {
+            entity.setStatus(status);
+            categoryMapper.updateById(entity);
+        }
+    }
+}

--- a/fend/src/views/KmsKnowledge.vue
+++ b/fend/src/views/KmsKnowledge.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
   <el-container class="kms-knowledge">
-    <el-aside width="240px" class="kms-tree">
+    <el-aside width="40%" class="kms-tree">
       <div class="tree-toolbar">
         <el-button type="primary" size="mini" @click="openCategoryDialog()">新建类目</el-button>
       </div>
@@ -24,12 +24,6 @@
             </el-tooltip>
             <el-tooltip content="删除" placement="top">
               <i class="el-icon-delete" @click.stop="deleteCategory(data)"></i>
-            </el-tooltip>
-            <el-tooltip content="上移" placement="top">
-              <i class="el-icon-arrow-up" @click.stop="moveCategory(data, 'up')"></i>
-            </el-tooltip>
-            <el-tooltip content="下移" placement="top">
-              <i class="el-icon-arrow-down" @click.stop="moveCategory(data, 'down')"></i>
             </el-tooltip>
             <el-switch
               v-model="data.status"
@@ -133,14 +127,20 @@
         </el-select>
       </el-form-item>
       
-      <el-form-item label="排序">
-        <el-input-number v-model="categoryForm.sort" :min="0"></el-input-number>
+      <el-form-item label="推荐">
+        <el-select v-model="categoryForm.recommend">
+          <el-option label="否" :value="0"></el-option>
+          <el-option label="是" :value="1"></el-option>
+        </el-select>
       </el-form-item>
       <el-form-item label="状态">
         <el-select v-model="categoryForm.status">
           <el-option label="启用" :value="1"></el-option>
           <el-option label="停用" :value="0"></el-option>
         </el-select>
+      </el-form-item>
+      <el-form-item label="备注">
+        <el-input v-model="categoryForm.remark"></el-input>
       </el-form-item>
     </el-form>
     <div slot="footer">
@@ -226,8 +226,9 @@ export default {
         id: null,
         name: '',
         parent_id: null,
-        sort: 0,
-        status: 1
+        recommend: 0,
+        status: 1,
+        remark: ''
       },
       queryForm: {
         keywords: '',
@@ -296,8 +297,9 @@ export default {
         id: null,
         name: '',
         parent_id: parent ? parent.id : null,
-        sort: 0,
-        status: 1
+        recommend: 0,
+        status: 1,
+        remark: ''
       }
       this.categoryDialogVisible = true
     },
@@ -330,14 +332,6 @@ export default {
           this.$message.error(e.message)
         }
       }).catch(() => {})
-    },
-    async moveCategory (data, direction) {
-      try {
-        await http.post('/category/sort', { id: data.id, direction })
-        this.fetchCategoryTree()
-      } catch (e) {
-        this.$message.error(e.message)
-      }
     },
     async toggleCategoryStatus (data) {
       try {

--- a/fend/src/views/KnowledgePage.vue
+++ b/fend/src/views/KnowledgePage.vue
@@ -90,14 +90,12 @@
 </template>
 
 <script>
+import http from '../api/http'
 export default {
   name: 'KnowledgePage',
   data () {
     return {
-      categories: [
-        { id: 1, name: '类目一', children: [{ id: 2, name: '子类目' }] },
-        { id: 3, name: '类目二' }
-      ],
+      categories: [],
       query: {
         category: null,
         title: '',
@@ -124,7 +122,18 @@ export default {
       ]
     }
   },
+  mounted () {
+    this.fetchCategories()
+  },
   methods: {
+    async fetchCategories () {
+      try {
+        const data = await http.get('/category/tree')
+        this.categories = data || []
+      } catch (e) {
+        this.$message.error(e.message)
+      }
+    },
     viewCategory (row) {
       this.$message.info(`查看 ${row.name}`)
     },
@@ -166,7 +175,7 @@ export default {
   height: 100%;
 }
 .category-panel {
-  width: 30%;
+  width: 40%;
   border-right: 1px solid #ebeef5;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- implement category entity, mapper, service and REST controller
- fetch and edit categories on frontend with 40% width panel
- add recommend and remark fields for category dialog

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a558d23608833391f51f9c35a07d55