### PR TITLE
feat: extend knowledge page filters

### DIFF
--- a/bend/pom.xml
+++ b/bend/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>springdoc-openapi-ui</artifactId>
       <version>1.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bend/src/main/java/com/kms/controller/KnowledgeController.java
+++ b/bend/src/main/java/com/kms/controller/KnowledgeController.java
@@ -5,8 +5,11 @@ import com.kms.dto.KnowledgeCreateReq;
 import com.kms.dto.KnowledgeUpdateReq;
 import com.kms.dto.PageReq;
 import com.kms.service.KnowledgeService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/knowledge")
@@ -22,8 +25,15 @@ public class KnowledgeController {
     public R<?> page(PageReq pageReq,
                      @RequestParam(required = false) String title,
                      @RequestParam(required = false) String keywords,
-                     @RequestParam(required = false) Integer status) {
-        return R.ok(knowledgeService.page(pageReq, title, keywords, status));
+                     @RequestParam(required = false) Integer status,
+                     @RequestParam(required = false) String categoryName,
+                     @RequestParam(required = false) String tagName,
+                     @RequestParam(required = false) String visibilityName,
+                     @RequestParam(required = false) Integer questionNo,
+                     @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+                     @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
+        return R.ok(knowledgeService.page(pageReq, title, keywords, status,
+                categoryName, tagName, visibilityName, questionNo, startDate, endDate));
     }
 
     @GetMapping("/{id}")

--- a/bend/src/main/java/com/kms/service/KnowledgeService.java
+++ b/bend/src/main/java/com/kms/service/KnowledgeService.java
@@ -6,8 +6,12 @@ import com.kms.dto.PageReq;
 import com.kms.dto.PageResp;
 import com.kms.entity.KnowledgeDO;
 
+import java.time.LocalDate;
+
 public interface KnowledgeService {
-    PageResp<KnowledgeDO> page(PageReq req, String title, String keywords, Integer status);
+    PageResp<KnowledgeDO> page(PageReq req, String title, String keywords, Integer status,
+                              String categoryName, String tagName, String visibilityName,
+                              Integer questionNo, LocalDate startDate, LocalDate endDate);
     KnowledgeDO get(Long id);
     void create(KnowledgeCreateReq req);
     void update(Long id, KnowledgeUpdateReq req);

--- a/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
+++ b/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
@@ -12,6 +12,8 @@ import com.kms.service.KnowledgeService;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 public class KnowledgeServiceImpl implements KnowledgeService {
 
@@ -22,7 +24,9 @@ public class KnowledgeServiceImpl implements KnowledgeService {
     }
 
     @Override
-    public PageResp<KnowledgeDO> page(PageReq req, String title, String keywords, Integer status) {
+    public PageResp<KnowledgeDO> page(PageReq req, String title, String keywords, Integer status,
+                                      String categoryName, String tagName, String visibilityName,
+                                      Integer questionNo, LocalDate startDate, LocalDate endDate) {
         QueryWrapper<KnowledgeDO> qw = new QueryWrapper<>();
         if (title != null && !title.isEmpty()) {
             qw.like("title", title);
@@ -32,6 +36,24 @@ public class KnowledgeServiceImpl implements KnowledgeService {
         }
         if (status != null) {
             qw.eq("status", status);
+        }
+        if (categoryName != null && !categoryName.isEmpty()) {
+            qw.eq("category_name", categoryName);
+        }
+        if (tagName != null && !tagName.isEmpty()) {
+            qw.eq("tag_name", tagName);
+        }
+        if (visibilityName != null && !visibilityName.isEmpty()) {
+            qw.eq("visibility_name", visibilityName);
+        }
+        if (questionNo != null) {
+            qw.eq("question_no", questionNo);
+        }
+        if (startDate != null) {
+            qw.ge("created_at", startDate.atStartOfDay());
+        }
+        if (endDate != null) {
+            qw.le("created_at", endDate.atTime(23, 59, 59));
         }
         Page<KnowledgeDO> page = knowledgeMapper.selectPage(new Page<>(req.getPage(), req.getPageSize()), qw);
         PageResp<KnowledgeDO> resp = new PageResp<>();

--- a/bend/src/test/java/com/kms/service/impl/KnowledgeServiceImplTest.java
+++ b/bend/src/test/java/com/kms/service/impl/KnowledgeServiceImplTest.java
@@ -1,0 +1,41 @@
+package com.kms.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.kms.dto.PageReq;
+import com.kms.entity.KnowledgeDO;
+import com.kms.mapper.KnowledgeMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class KnowledgeServiceImplTest {
+
+    @Test
+    void pageAddsFilters() {
+        KnowledgeMapper mapper = Mockito.mock(KnowledgeMapper.class);
+        Mockito.when(mapper.selectPage(Mockito.any(Page.class), Mockito.any(QueryWrapper.class)))
+                .thenReturn(new Page<>());
+        KnowledgeServiceImpl service = new KnowledgeServiceImpl(mapper);
+        PageReq req = new PageReq();
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 31);
+        service.page(req, null, null, null, "cat", "tag", "vis", 1, startDate, endDate);
+
+        ArgumentCaptor<QueryWrapper<KnowledgeDO>> captor = ArgumentCaptor.forClass(QueryWrapper.class);
+        Mockito.verify(mapper).selectPage(Mockito.any(Page.class), captor.capture());
+        String sql = captor.getValue().getSqlSegment();
+
+        assertTrue(sql.contains("category_name"));
+        assertTrue(sql.contains("tag_name"));
+        assertTrue(sql.contains("visibility_name"));
+        assertTrue(sql.contains("question_no"));
+        assertTrue(sql.contains("created_at >="));
+        assertTrue(sql.contains("created_at <="));
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand knowledge page API with category, tag, visibility, question number and date range filters
- apply new filters in service layer QueryWrapper and keep keyword search
- add unit test for service filtering and include test dependencies

## Testing
- `mvn -f bend/pom.xml test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a599d34e888333a4aefc435c676cb2