### PR TITLE
Configure upload directory path

### DIFF
--- a/bend/src/main/resources/application.yml
+++ b/bend/src/main/resources/application.yml
@@ -31,4 +31,4 @@ logging:
     com.zaxxer.hikari: info
 
 upload:
-  dir: /uploads
+  dir: "D:/GithubRepositories/upload"


### PR DESCRIPTION
## Summary
- point `upload.dir` at `D:/GithubRepositories/upload`
- rely on `@Value("${upload.dir}")` in controllers and web config to resolve the path

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a67eacd2f4833397bf7b4865590025