### PR TITLE
Add createdBy field and improve attachment uploads

### DIFF
--- a/bend/src/main/java/com/kms/dto/AttachmentUploadResp.java
+++ b/bend/src/main/java/com/kms/dto/AttachmentUploadResp.java
@@ -1,0 +1,11 @@
+package com.kms.dto;
+
+import lombok.Data;
+
+@Data
+public class AttachmentUploadResp {
+    private Long id;
+    private String name;
+    private String url;
+    private Long size;
+}

--- a/bend/src/main/java/com/kms/service/AttachmentService.java
+++ b/bend/src/main/java/com/kms/service/AttachmentService.java
@@ -9,5 +9,6 @@ public interface AttachmentService {
     List<AttachmentDTO> listByKnowledgeId(Long knowledgeId);
     void removeByKnowledgeId(Long knowledgeId);
     void removeById(Long id);
+    AttachmentDTO getById(Long id);
 }
 

--- a/bend/src/main/java/com/kms/service/impl/AttachmentServiceImpl.java
+++ b/bend/src/main/java/com/kms/service/impl/AttachmentServiceImpl.java
@@ -26,6 +26,14 @@ public class AttachmentServiceImpl implements AttachmentService {
             return;
         }
         for (AttachmentDTO dto : attachments) {
+            if (dto.getId() != null) {
+                AttachmentDO entity = attachmentMapper.selectById(dto.getId());
+                if (entity != null) {
+                    entity.setKnowledgeId(knowledgeId);
+                    attachmentMapper.updateById(entity);
+                    continue;
+                }
+            }
             AttachmentDO entity = new AttachmentDO();
             entity.setKnowledgeId(knowledgeId);
             entity.setFilePath(dto.getUrl());
@@ -55,6 +63,19 @@ public class AttachmentServiceImpl implements AttachmentService {
     @Override
     public void removeById(Long id) {
         attachmentMapper.deleteById(id);
+    }
+
+    @Override
+    public AttachmentDTO getById(Long id) {
+        AttachmentDO entity = attachmentMapper.selectById(id);
+        if (entity == null) {
+            return null;
+        }
+        AttachmentDTO dto = new AttachmentDTO();
+        BeanUtils.copyProperties(entity, dto);
+        dto.setUrl(entity.getFilePath());
+        dto.setFileName(entity.getFilePath());
+        return dto;
     }
 }
 

--- a/fend/src/views/KmsKnowledge.vue
+++ b/fend/src/views/KmsKnowledge.vue
@@ -232,6 +232,9 @@
         <el-form-item label="问题序号">
           <el-input-number v-model="knowledgeForm.questionNo" :min="1"></el-input-number>
         </el-form-item>
+        <el-form-item label="创建人">
+          <el-input v-model="knowledgeForm.createdBy"></el-input>
+        </el-form-item>
         <el-form-item label="摘要">
           <el-input type="textarea" v-model="knowledgeForm.summary"></el-input>
         </el-form-item>
@@ -337,6 +340,7 @@ export default {
         keywords: '',
         status: 1,
         questionNo: 1,
+        createdBy: '',
         summary: '',
         content: '',
         attachments: []
@@ -485,8 +489,10 @@ export default {
         this.knowledgeDialogTitle = '编辑知识'
         this.knowledgeForm = Object.assign({}, row, {
           attachments: (row.attachments || []).map(a => ({
-            ...a,
-            name: a.fileName
+            id: a.id,
+            name: a.fileName || a.name,
+            url: a.url,
+            size: a.size
           }))
         })
       } else {
@@ -501,6 +507,7 @@ export default {
           keywords: '',
           status: 1,
           questionNo: this.tableData.length + 1,
+          createdBy: '',
           summary: '',
           content: '',
           attachments: []
@@ -539,7 +546,7 @@ export default {
             ...this.knowledgeForm,
             attachments: (this.knowledgeForm.attachments || []).map(a => ({
               id: a.id,
-              fileName: a.fileName || a.name,
+              fileName: a.name || a.fileName,
               url: a.url
             }))
           }
@@ -632,13 +639,13 @@ export default {
 
     uploadAttachment(request) {
       apiUploadAttachment(request.file).then(data => {
+        request.onSuccess(data, request.file)
         this.knowledgeForm.attachments.push({
           id: data.id,
-          fileName: data.fileName,
+          name: data.name,
           url: data.url,
-          name: data.fileName
+          size: data.size
         })
-        request.onSuccess()
       }).catch(err => {
         this.$message.error(err.message)
         request.onError()
@@ -662,9 +669,9 @@ export default {
         this.$message.success('删除成功')
         this.knowledgeForm.attachments = fileList.map(f => ({
           id: f.id,
-          fileName: f.fileName || f.name,
+          name: f.name,
           url: f.url,
-          name: f.name
+          size: f.size
         }))
       }).catch(e => {
         this.$message.error(e.message)


### PR DESCRIPTION
## Summary
- Capture creator information for knowledge items
- Persist uploaded files and return attachment metadata from backend

## Testing
- `npm test --prefix fend` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a68896bcb88333ac814b66cb13d7ab