### PR TITLE
Handle knowledgeId for attachment uploads

### DIFF
--- a/bend/src/main/java/com/kms/controller/AttachmentController.java
+++ b/bend/src/main/java/com/kms/controller/AttachmentController.java
@@ -34,7 +34,8 @@ public class AttachmentController {
     }
 
     @PostMapping("/upload")
-    public AttachmentUploadResp upload(@RequestPart("file") MultipartFile file) throws IOException {
+    public AttachmentUploadResp upload(@RequestPart("file") MultipartFile file,
+                                       @RequestParam("knowledgeId") Long knowledgeId) throws IOException {
         Path dir = Paths.get(uploadDir);
         if (!Files.exists(dir)) {
             Files.createDirectories(dir);
@@ -44,7 +45,7 @@ public class AttachmentController {
         file.transferTo(dest.toFile());
         AttachmentDTO dto = new AttachmentDTO();
         dto.setUrl(filename);
-        attachmentService.saveBatch(null, Collections.singletonList(dto));
+        attachmentService.saveBatch(knowledgeId, Collections.singletonList(dto));
         AttachmentUploadResp resp = new AttachmentUploadResp();
         resp.setId(dto.getId());
         resp.setName(filename);

--- a/fend/src/api/attachment.js
+++ b/fend/src/api/attachment.js
@@ -1,8 +1,9 @@
 import http from './http'
 
-export function uploadAttachment(file) {
+export function uploadAttachment(file, knowledgeId) {
   const formData = new FormData()
   formData.append('file', file)
+  formData.append('knowledgeId', knowledgeId)
   return http.post('/attachment/upload', formData, {
     // headers: {'Content-Type': 'multipart/form-data'}
   })

--- a/fend/src/views/KmsKnowledge.vue
+++ b/fend/src/views/KmsKnowledge.vue
@@ -638,7 +638,12 @@ export default {
     },
 
     uploadAttachment(request) {
-      apiUploadAttachment(request.file).then(data => {
+      if (!this.knowledgeForm.id) {
+        this.$message.error('请先保存知识')
+        request.onError()
+        return
+      }
+      apiUploadAttachment(request.file, this.knowledgeForm.id).then(data => {
         request.onSuccess(data, request.file)
         this.knowledgeForm.attachments.push({
           id: data.id,


### PR DESCRIPTION
## Summary
- pass knowledgeId with attachment upload requests in front-end and back-end
- show error when trying to upload attachments without a saved knowledge record
- persist uploaded attachments to the provided knowledge id server-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a69270fe2883339b3c848e91ca0149