### PR TITLE
refactor: share knowledge data via composables

### DIFF
--- a/fend/src/components/KnowledgeFilter.vue
+++ b/fend/src/components/KnowledgeFilter.vue
@@ -13,7 +13,7 @@
         >
           <el-tree
             ref="catTree"
-            :data="categoryTree"
+            :data="categoryState.categoryTree"
             node-key="id"
             show-checkbox
             :props="{ label: 'name', children: 'children' }"
@@ -30,7 +30,7 @@
             @close="removeCat(id)"
             class="tag-chip"
           >
-            {{ id2name[id] || id }}
+            {{ categoryState.id2name[id] || id }}
           </el-tag>
         </div>
       </el-form-item>
@@ -47,7 +47,7 @@
         <el-tag>标签</el-tag>
         <el-select v-model="queryForm.tagName" placeholder="请选择标签" clearable>
           <el-option
-            v-for="item in tagOptions"
+            v-for="item in tagState.tagOptions"
             :key="item.id"
             :label="item.name"
             :value="item.name"
@@ -105,21 +105,12 @@
 </template>
 
 <script>
+import { useCategory } from '@/composables/useCategory'
+import { useTag } from '@/composables/useTag'
+
 export default {
   name: 'KnowledgeFilter',
   props: {
-    categoryTree: {
-      type: Array,
-      default: () => []
-    },
-    id2name: {
-      type: Object,
-      default: () => ({})
-    },
-    tagOptions: {
-      type: Array,
-      default: () => []
-    },
     visibilityOptions: {
       type: Array,
       default: () => []
@@ -130,7 +121,11 @@ export default {
     }
   },
   data() {
+    const { state: categoryState } = useCategory()
+    const { state: tagState } = useTag()
     return {
+      categoryState,
+      tagState,
       queryForm: {
         categoryIds: [],
         title: '',

--- a/fend/src/composables/useCategory.js
+++ b/fend/src/composables/useCategory.js
@@ -1,0 +1,39 @@
+import Vue from 'vue'
+import http from '@/api/http'
+import { getRelatedCategories } from '@/api/category'
+
+const state = Vue.observable({
+  categoryTree: [],
+  flatCategories: [],
+  id2name: {},
+  currentCategoryId: null,
+  relatedCategory: []
+})
+
+async function loadCategoryTree() {
+  const data = await http.get('/category/tree')
+  state.categoryTree = data || []
+  state.flatCategories = []
+  state.id2name = {}
+  const walk = nodes => {
+    nodes.forEach(n => {
+      state.flatCategories.push({ id: n.id, name: n.name })
+      state.id2name[n.id] = n.name
+      if (n.children) walk(n.children)
+    })
+  }
+  walk(state.categoryTree)
+  if (state.categoryTree.length && !state.currentCategoryId) {
+    state.currentCategoryId = state.categoryTree[0].id
+  }
+  await loadRelatedCategory()
+}
+
+async function loadRelatedCategory() {
+  const data = await getRelatedCategories()
+  state.relatedCategory = data || []
+}
+
+export function useCategory() {
+  return { state, loadCategoryTree, loadRelatedCategory }
+}

--- a/fend/src/composables/useKnowledge.js
+++ b/fend/src/composables/useKnowledge.js
@@ -1,0 +1,32 @@
+import Vue from 'vue'
+import { getKnowledgeList } from '@/api/knowledge'
+
+const state = Vue.observable({
+  tableData: [],
+  pagination: {
+    page: 1,
+    pageSize: 10,
+    total: 0
+  }
+})
+
+async function loadKnowledgeList(filters) {
+  const params = {
+    relatedCategoryIds: filters.categoryIds,
+    title: filters.title,
+    tagName: filters.tagName,
+    status: filters.status,
+    visibilityName: filters.visibilityName,
+    questionNo: filters.questionNo,
+    createdAt: filters.createdAt,
+    page: state.pagination.page,
+    pageSize: state.pagination.pageSize
+  }
+  const data = await getKnowledgeList(params)
+  state.tableData = data.records
+  state.pagination.total = data.total
+}
+
+export function useKnowledge() {
+  return { state, loadKnowledgeList }
+}

--- a/fend/src/composables/useTag.js
+++ b/fend/src/composables/useTag.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import { getAllTags } from '@/api/tag'
+
+const state = Vue.observable({
+  tagOptions: []
+})
+
+async function loadTag() {
+  const data = await getAllTags()
+  state.tagOptions = data || []
+}
+
+export function useTag() {
+  return { state, loadTag }
+}


### PR DESCRIPTION
## Summary
- add composables for categories, tags, and knowledge list
- refactor filter, table, and main view to use shared state
- reduce API calls inside view components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a7e6bb5f588333b5b05a38488c5923