### PR TITLE
Refactor knowledge search API usage

### DIFF
--- a/fend/src/api/knowledge.js
+++ b/fend/src/api/knowledge.js
@@ -1,18 +1,12 @@
 import http from './http'
 
-export function getKnowledgeList(params) {
-  return http.get('/knowledge', { params })
+export function searchKnowledge(params) {
+  return http.post('/knowledge/search', params)
 }
 
 export function getKnowledge(id) {
   return http.get(`/knowledge/${id}`)
 }
-
-export function search(id) {
-  return http.post(`/knowledge/search`)
-}
-
-
 
 export function createKnowledge(data) {
   return http.post('/knowledge', data)

--- a/fend/src/components/KnowledgeTable.vue
+++ b/fend/src/components/KnowledgeTable.vue
@@ -70,10 +70,10 @@ export default {
     }
   },
   data() {
-    const { state, loadKnowledgeList } = useKnowledge()
+    const { state, search } = useKnowledge()
     return {
       knowledgeState: state,
-      fetchKnowledgeList: loadKnowledgeList,
+      search,
       tableHeight: 400
     }
   },
@@ -110,7 +110,7 @@ export default {
       this.$emit('selection-change', val)
     },
     async loadData() {
-      await this.fetchKnowledgeList({ ...this.filters })
+      await this.search({ ...this.filters })
       this.$emit('pagination-change', { ...this.knowledgeState.pagination })
     }
   }

--- a/fend/src/composables/useKnowledge.js
+++ b/fend/src/composables/useKnowledge.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { getKnowledgeList } from '@/api/knowledge'
+import { searchKnowledge } from '@/api/knowledge'
 
 const state = Vue.observable({
   tableData: [],
@@ -10,23 +10,24 @@ const state = Vue.observable({
   }
 })
 
-async function loadKnowledgeList(filters) {
-  const params = {
-    relatedCategoryIds: filters.categoryIds,
+async function search(filters = {}) {
+  const payload = {
+    relatedCategories: filters.categoryIds,
     title: filters.title,
     tagName: filters.tagName,
     status: filters.status,
     visibilityName: filters.visibilityName,
     questionNo: filters.questionNo,
-    createdAt: filters.createdAt,
+    startDate: filters.createdAt && filters.createdAt.length ? filters.createdAt[0] : '',
+    endDate: filters.createdAt && filters.createdAt.length ? filters.createdAt[1] : '',
     page: state.pagination.page,
     pageSize: state.pagination.pageSize
   }
-  const data = await getKnowledgeList(params)
+  const data = await searchKnowledge(payload)
   state.tableData = data.records
   state.pagination.total = data.total
 }
 
 export function useKnowledge() {
-  return { state, loadKnowledgeList }
+  return { state, search }
 }


### PR DESCRIPTION
## Summary
- replace legacy knowledge list/search endpoints with unified `searchKnowledge`
- update knowledge composable to build backend-specific payload and split date range
- adjust table component to call new search function for initial data load

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a7eae3e0208333a0b5a2b704cc3fe6