### PR TITLE
feat: add search endpoint for knowledge queries

### DIFF
--- a/bend/src/main/java/com/kms/controller/KnowledgeController.java
+++ b/bend/src/main/java/com/kms/controller/KnowledgeController.java
@@ -40,6 +40,11 @@ public class KnowledgeController {
                 relatedCategories, tagName, visibilityName, questionNo, startDate, endDate));
     }
 
+    @PostMapping("/search")
+    public R<?> search(@RequestBody KnowledgeQueryReq req) {
+        return R.ok(knowledgeService.page(req));
+    }
+
     @GetMapping("/{id}")
     public R<?> get(@PathVariable Long id) {
         return R.ok(knowledgeService.get(id));

--- a/bend/src/main/java/com/kms/dto/KnowledgeQueryReq.java
+++ b/bend/src/main/java/com/kms/dto/KnowledgeQueryReq.java
@@ -16,5 +16,7 @@ public class KnowledgeQueryReq extends PageReq {   // PageReq 含 page, pageSize
     private String visibilityName;
     private Integer questionNo;
     @JsonFormat(pattern = "yyyy-MM-dd")
-    private LocalDate createdDate;
+    private LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 }

--- a/bend/src/main/java/com/kms/service/KnowledgeService.java
+++ b/bend/src/main/java/com/kms/service/KnowledgeService.java
@@ -2,6 +2,7 @@ package com.kms.service;
 
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.kms.dto.KnowledgeCreateReq;
+import com.kms.dto.KnowledgeQueryReq;
 import com.kms.dto.KnowledgeUpdateReq;
 import com.kms.dto.PageReq;
 import com.kms.dto.PageResp;
@@ -36,4 +37,6 @@ public interface KnowledgeService {
                             Integer questionNo,
                             LocalDate startDate,
                             LocalDate endDate);
+
+    IPage<KnowledgeDO> page(KnowledgeQueryReq req);
 }

--- a/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
+++ b/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
@@ -96,6 +96,24 @@ public class KnowledgeServiceImpl implements KnowledgeService {
     }
 
     @Override
+    public IPage<KnowledgeDO> page(KnowledgeQueryReq req) {
+        Page<KnowledgeDO> page = new Page<>(req.getPage(), req.getPageSize());
+
+        KnowledgeFilterParam p = new KnowledgeFilterParam();
+        p.setTitle(req.getTitle());
+        p.setKeywords(req.getKeywords());
+        p.setStatus(req.getStatus());
+        p.setRelatedCategories(req.getRelatedCategories());
+        p.setTagName(req.getTagName());
+        p.setVisibilityName(req.getVisibilityName());
+        p.setQuestionNo(req.getQuestionNo());
+        p.setStartDate(req.getStartDate());
+        p.setEndDate(req.getEndDate());
+
+        return knowledgeMapper.selectPageByFilters(page, p);
+    }
+
+    @Override
     public KnowledgeDO get(Long id) {
         KnowledgeDO entity = knowledgeMapper.selectById(id);
         AttachmentDTO attachments = attachmentService.getByKId(id);

--- a/bend/src/main/resources/mapper/KnowledgeMapper.xml
+++ b/bend/src/main/resources/mapper/KnowledgeMapper.xml
@@ -6,19 +6,14 @@
     <select id="selectPageByFilters" resultType="com.kms.entity.KnowledgeDO">
         SELECT k.*
         FROM knowledge k
-        <if test="p.relatedCategories != null and p.relatedCategories.size() > 0">
-            JOIN (
-            SELECT kid
-            FROM cok
-            WHERE name IN
-            <foreach collection="p.relatedCategories" item="n" open="(" separator="," close=")">
-                #{n}
-            </foreach>
-            GROUP BY kid
-            HAVING COUNT(DISTINCT name) = #{p.relatedCategories.size}
-            ) c ON c.kid = k.id
-        </if>
         <where>
+            <if test="p.relatedCategories != null and p.relatedCategories.size() > 0">
+                AND (
+                <foreach collection="p.relatedCategories" item="rc" separator=" OR ">
+                    FIND_IN_SET(#{rc}, k.related_categories)
+                </foreach>
+                )
+            </if>
             <if test="p.title != null and p.title != ''">
                 AND k.title LIKE CONCAT('%', #{p.title}, '%')
             </if>


### PR DESCRIPTION
## Summary
- add `/knowledge/search` endpoint that accepts `KnowledgeQueryReq`
- encapsulate filtering logic with `KnowledgeService.page(KnowledgeQueryReq)`
- support related category and date filters in mapper SQL

## Testing
- `mvn -q test` *(fails: Network is unreachable for org.springframework.boot:spring-boot-starter-parent:pom:2.7.18)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eae588788333bd44225323e95975