### PR TITLE
Use category names for knowledge filtering

### DIFF
--- a/bend/src/main/resources/mapper/KnowledgeMapper.xml
+++ b/bend/src/main/resources/mapper/KnowledgeMapper.xml
@@ -7,12 +7,11 @@
         SELECT k.*
         FROM knowledge k
         <where>
-            <if test="p.relatedCategories != null and p.relatedCategories.size() > 0">
-                AND (
-                <foreach collection="p.relatedCategories" item="rc" separator=" OR ">
-                    FIND_IN_SET(#{rc}, k.related_categories)
+            <if test="p.relatedCategories != null && !p.relatedCategories.isEmpty()">
+                AND k.category_name IN
+                <foreach collection="p.relatedCategories" item="rc" open="(" separator="," close=")">
+                    #{rc}
                 </foreach>
-                )
             </if>
             <if test="p.title != null and p.title != ''">
                 AND k.title LIKE CONCAT('%', #{p.title}, '%')

--- a/fend/src/composables/useKnowledge.js
+++ b/fend/src/composables/useKnowledge.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import { searchKnowledge } from '@/api/knowledge'
+import { useCategory } from '@/composables/useCategory'
 
 const state = Vue.observable({
   tableData: [],
@@ -10,9 +11,11 @@ const state = Vue.observable({
   }
 })
 
+const { state: categoryState } = useCategory()
+
 async function search(filters = {}) {
   const payload = {
-    relatedCategories: filters.categoryIds,
+    relatedCategories: (filters.categoryIds || []).map(id => categoryState.id2name[id]).filter(Boolean),
     title: filters.title,
     tagName: filters.tagName,
     status: filters.status,


### PR DESCRIPTION
## Summary
- Filter knowledge by category names via `k.category_name IN (...)`
- Send category names from client instead of IDs when searching

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7ee04d1888333b28a2b3ffd444858