### PR TITLE
Add category name to KnowledgeDO

### DIFF
--- a/bend/src/main/java/com/kms/entity/KnowledgeDO.java
+++ b/bend/src/main/java/com/kms/entity/KnowledgeDO.java
@@ -21,6 +21,9 @@ public class KnowledgeDO {
 
     private String title;
 
+    @TableField("category_name")
+    private String categoryName;
+
     private String tagName;
 
     private String visibilityName;
@@ -41,5 +44,8 @@ public class KnowledgeDO {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    @TableField(exist = false)
+    private List<AttachmentDTO> attachments;
 
 }

--- a/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
+++ b/bend/src/main/java/com/kms/service/impl/KnowledgeServiceImpl.java
@@ -8,7 +8,6 @@ import com.kms.service.AttachmentService;
 import com.kms.entity.KnowledgeDO;
 import com.kms.mapper.KnowledgeMapper;
 import com.kms.service.KnowledgeService;
-import com.kms.vo.KnowledgeDetailVO;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
@@ -116,10 +115,8 @@ public class KnowledgeServiceImpl implements KnowledgeService {
     @Override
     public KnowledgeDO get(Long id) {
         KnowledgeDO entity = knowledgeMapper.selectById(id);
-        AttachmentDTO attachments = attachmentService.getByKId(id);
-
-        KnowledgeDetailVO knowledgeDetailVO = new KnowledgeDetailVO();
-
+        List<AttachmentDTO> attachments = attachmentService.listByKnowledgeId(id);
+        entity.setAttachments(attachments);
         return entity;
     }
 

--- a/bend/src/test/java/com/kms/service/impl/KnowledgeServiceImplTest.java
+++ b/bend/src/test/java/com/kms/service/impl/KnowledgeServiceImplTest.java
@@ -57,6 +57,9 @@ public class KnowledgeServiceImplTest {
         req.setContent("cnt");
         req.setAttachments(java.util.Collections.singletonList(new AttachmentDTO()));
         service.create(req);
+        ArgumentCaptor<KnowledgeDO> captor = ArgumentCaptor.forClass(KnowledgeDO.class);
+        Mockito.verify(mapper).insert(captor.capture());
+        org.junit.jupiter.api.Assertions.assertEquals("c", captor.getValue().getCategoryName());
         Mockito.verify(attachmentService).saveBatch(Mockito.anyLong(), Mockito.anyList());
     }
 
@@ -92,11 +95,14 @@ public class KnowledgeServiceImplTest {
         Mockito.when(mapper.selectById(1L)).thenReturn(existing);
         KnowledgeServiceImpl service = new KnowledgeServiceImpl(mapper, attachmentService);
         KnowledgeUpdateReq req = new KnowledgeUpdateReq();
+        req.setCategoryName("c2");
         req.setAttachments(java.util.Collections.singletonList(new AttachmentDTO()));
         service.update(1L, req);
         Mockito.verify(attachmentService).removeByKnowledgeId(1L);
         Mockito.verify(attachmentService).saveBatch(1L, req.getAttachments());
-        Mockito.verify(mapper).updateById(Mockito.any(KnowledgeDO.class));
+        ArgumentCaptor<KnowledgeDO> updateCaptor = ArgumentCaptor.forClass(KnowledgeDO.class);
+        Mockito.verify(mapper).updateById(updateCaptor.capture());
+        org.junit.jupiter.api.Assertions.assertEquals("c2", updateCaptor.getValue().getCategoryName());
     }
 }
 


### PR DESCRIPTION
## Summary
- track knowledge category name via new `categoryName` field on KnowledgeDO
- populate attachments when retrieving knowledge entries
- verify create/update operations copy `categoryName` into persistence layer

## Testing
- `mvn -q -f bend/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ee075d408333936e1d2dcd4df977