### PR TITLE
fix: revise relatedCategories condition in KnowledgeMapper

### DIFF
--- a/bend/src/main/resources/mapper/KnowledgeMapper.xml
+++ b/bend/src/main/resources/mapper/KnowledgeMapper.xml
@@ -7,7 +7,7 @@
         SELECT k.*
         FROM knowledge k
         <where>
-            <if test="p.relatedCategories != null && !p.relatedCategories.isEmpty()">
+            <if test="p.relatedCategories != null and p.relatedCategories.size > 0">
                 AND k.category_name IN
                 <foreach collection="p.relatedCategories" item="rc" open="(" separator="," close=")">
                     #{rc}


### PR DESCRIPTION
## Summary
- simplify related categories filter condition to use MyBatis-friendly syntax

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f18c0dd48333ad6a570434930928